### PR TITLE
feat(skip_lines) + optimizations

### DIFF
--- a/ev3/pixel_plotter.py
+++ b/ev3/pixel_plotter.py
@@ -1,22 +1,74 @@
+#!/usr/bin/env pybricks-micropython
+from pybricks.hubs import EV3Brick
+from pybricks.ev3devices import Motor
+from pybricks.parameters import Port
+import time
+
+PIXELS = 40
+# Speeds
+SPEED_NEW_PIXEL = -25
+SPEED_NEW_LINE = 50
+SPEED_PAPER = -100
+SPEED_PEN = 20
+# Angles
+PAPER_NEW_LINE = 1200 // PIXELS
+ARM_NEW_LINE = 430
+NEW_PIXEL = ARM_NEW_LINE // PIXELS
+# Relative angles
+PEN_DOWN = 0 # relative positional degree from 0 which is at top
+PEN_UP = -5 # relative positional degree
+
 class PixelPlotter:
+
     def __init__(self):
-        self.image_array = []
+        self.image_array = self.set_image_array()
+
+        self.ev3 = EV3Brick()
+        self.arm = Motor(Port.A)
+        self.paper = Motor(Port.B)
+        self.pen = Motor(Port.C)
+
+        self.print()
+
     
-    # this function reads the file and converts it to a python array
+    # reads the file and converts it to a python array
     def set_image_array(self):
+        array = []
         with open("image_array.txt", "r") as f:
-            for i, r in enumerate(f.readlines()):
+            for r in f.readlines():
                 # removes any spaces or newline characters
-                self.image_array.append([value for value in r if value in ("0", "1")])
+                array.append([value for value in r if value in ("0", "1")])
+
+        return array
+
+    # main method for printing
+    def print(self):
+        for print_line in self.image_array:
+            for pixel in print_line:
+                self.move_pen(pixel)
+                self.move_arm()
+            self.new_line()
+            
+    # moves pen up or down
+    def move_pen(self, pixel):
+        if pixel == "1":
+            print("DOWN")
+            self.pen.run_target(SPEED_PEN, PEN_DOWN)
+            self.pen.run_target(SPEED_PEN, PEN_UP)
+
+    # Moves arm for every pixel
+    def move_arm(self):
+        self.arm.run_angle(SPEED_NEW_PIXEL, NEW_PIXEL)
+
+    # moves paper down and arm back
+    def new_line(self):
+        self.arm.run_angle(SPEED_NEW_LINE, ARM_NEW_LINE)
+        self.paper.run_angle(SPEED_PAPER, PAPER_NEW_LINE)
 
 
-            #for i in self.image_array:
-            #    print(i, "\n")
-            #tmp = [line.split(" ") for line in f.readlines()]
-            #newList = [x for i in tmp for j, x in enumerate(i) if j%2 != 0]
+         
+def main():
+    PixelPlotter()
 
-    
 if __name__ == "__main__":
-    pp = PixelPlotter()
-    pp.set_image_array()
-    #print(pp.image_array)
+    main()

--- a/ev3/pixel_plotter.py
+++ b/ev3/pixel_plotter.py
@@ -28,6 +28,8 @@ class PixelPlotter:
         self.paper = Motor(Port.B)
         self.pen = Motor(Port.C)
 
+        self.arm_at_start = True
+
         self.print()
 
     
@@ -44,17 +46,32 @@ class PixelPlotter:
     # main method for printing
     def print(self):
         for print_line in self.image_array:
-            for pixel in print_line:
-                self.move_pen(pixel)
-                self.move_arm()
+            # if there is nothing to draw in a line, we skip it
+            if "1" in print_line:
+                # instead of always moving the arm back to it's start position
+                # when on a new line, we can instead start drawing from the end
+                # position of the arm, as long as we reverse the array to be drawn
+                if not self.arm_at_start:  # if arm at the end, reverse array
+                    print_line = print_line[::-1]
+                    SPEED_NEW_PIXEL = 25  # change direction of arm speed
+                else:
+                    SPEED_NEW_PIXEL = -25
+
+                for pixel in print_line:
+                    if pixel == 1:
+                        self.move_pen(pixel)
+                    self.move_arm()
+
+                # arm is now at the opposite side
+                self.arm_at_start = not self.arm_at_start
+            
             self.new_line()
             
     # moves pen up or down
     def move_pen(self, pixel):
-        if pixel == "1":
-            print("DOWN")
-            self.pen.run_target(SPEED_PEN, PEN_DOWN)
-            self.pen.run_target(SPEED_PEN, PEN_UP)
+        print("DOWN")
+        self.pen.run_target(SPEED_PEN, PEN_DOWN)
+        self.pen.run_target(SPEED_PEN, PEN_UP)
 
     # Moves arm for every pixel
     def move_arm(self):
@@ -62,7 +79,7 @@ class PixelPlotter:
 
     # moves paper down and arm back
     def new_line(self):
-        self.arm.run_angle(SPEED_NEW_LINE, ARM_NEW_LINE)
+        # self.arm.run_angle(SPEED_NEW_LINE, ARM_NEW_LINE)
         self.paper.run_angle(SPEED_PAPER, PAPER_NEW_LINE)
 
 


### PR DESCRIPTION
Made two changes:

If there is no ones in the print_line array, we can skip it, instead of the previous version where we still iterate over it while moving the arm.

Made it possible to print in a "snaking pattern". Instead of always setting the arm at the start position after a line is drawn, we can continue drawing while arm moves backwards. In this case, we need to make sure the array is reversed, so it's drawn in correct order. We also need to make sure that if we are skipping a line, this should not interfere with the way we are drawing. This means we simply can't alternate between drawing left to right, and right to left. We need to keep track of at which point (start or end) the arm is at all times.